### PR TITLE
Adding ability to get unique nodes and instance-id

### DIFF
--- a/src/rv/actions.go
+++ b/src/rv/actions.go
@@ -19,7 +19,6 @@ const CACHE_TTL = 60 * time.Second
 var stdout io.Writer = os.Stdout
 var stderr io.Writer = os.Stderr
 
-
 type Node struct {
   id   string
   ip   string

--- a/src/rv/actions.go
+++ b/src/rv/actions.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -20,17 +19,24 @@ const CACHE_TTL = 60 * time.Second
 var stdout io.Writer = os.Stdout
 var stderr io.Writer = os.Stderr
 
-type NodeList map[string]string
+
+type Node struct {
+  id   string
+  ip   string
+  name string
+}
+
+type NodeList []Node
 
 func CMD(c *cli.Context) {
 	checkCache(c)
 
 	args := c.Args().First()
 
-	hosts := []string{}
+  var hosts []string
 
-	for name, ip := range allNodes() {
-		hosts = append(hosts, name, ip)
+	for _, v := range allNodes() {
+		hosts = append(hosts, v.ip)
 	}
 
 	r := strings.NewReplacer(hosts...)
@@ -57,12 +63,10 @@ func List(c *cli.Context) {
 	nodes := allNodes()
 
 	writer := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(writer, "Name\tPrivate IP Address")
+	fmt.Fprintln(writer, "Name\tInstance ID\tPrivate IP Address")
 
-	nodeNames := sortedNodeNames(nodes)
-
-	for _, name := range nodeNames {
-		fmt.Fprintf(writer, "%s\t%s\n", name, nodes[name])
+	for _, v := range nodes {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", v.name, v.id, v.ip)
 	}
 
 	writer.Flush()
@@ -73,25 +77,16 @@ func NodeIP(c *cli.Context) {
 
 	nodes := allNodes()
 	node := c.Args().First()
-	ip := nodes[node]
 
-	if ip == "" {
-		fmt.Printf("Node with name %s was not found\n", node)
-		os.Exit(1)
-	}
+  for _,v := range nodes {
+    if v.ip == node {
+	    fmt.Fprintln(stdout, v.ip)
+    } else if v.ip == "" {
+		  fmt.Printf("Node with name %s was not found\n", node)
+		  os.Exit(1)
+    }
+  }
 
-	fmt.Fprintln(stdout, ip)
-}
-
-func sortedNodeNames(nodeList NodeList) []string {
-	var names []string
-
-	for name, _ := range nodeList {
-		names = append(names, name)
-	}
-
-	sort.Strings(names)
-	return names
 }
 
 func allNodes() NodeList {
@@ -114,9 +109,10 @@ func allNodes() NodeList {
 
 	for _, reservation := range resp.Reservations {
 		for _, instance := range reservation.Instances {
+			id := instanceId(instance)
 			ip := ipAddr(instance)
 			name := instanceName(instance)
-			list[uniqueName(list, name)] = ip
+      list = append(list, Node{id, ip, name})
 		}
 	}
 
@@ -124,23 +120,12 @@ func allNodes() NodeList {
 	return list
 }
 
-func uniqueName(list NodeList, originalName string) string {
-	name := originalName
-
-	_, exists := list[originalName]
-	var postfix int
-
-	for exists {
-		postfix++
-		postfixName := fmt.Sprintf("%s-%d", originalName, postfix)
-		_, exists = list[postfixName]
-
-		if !exists {
-			name = postfixName
-		}
+func instanceId(instance *ec2.Instance) string {
+	if instance.InstanceId == nil {
+		return "UNASSIGNED"
+	} else {
+		return *instance.InstanceId
 	}
-
-	return name
 }
 
 func ipAddr(instance *ec2.Instance) string {

--- a/src/rv/actions_test.go
+++ b/src/rv/actions_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/codegangsta/cli"
+  
+  "github.com/codegangsta/cli"
 )
 
 func NewContext(args ...string) *cli.Context {
@@ -27,9 +27,21 @@ func StubOutput() (*bytes.Buffer, *bytes.Buffer) {
 }
 
 func Setup() {
+  nodeA := Node{
+    id: "abc123",
+    ip: "127.0.0.1",
+    name: "b-node.local",
+  }
+
+  nodeB := Node{
+    id: "xyz123",
+    ip: "127.0.0.2",
+    name: "a-node.local",
+  }
+
 	list := NodeList{
-		"b-node.local": "127.0.0.1",
-		"a-node.local": "127.0.0.2",
+    nodeA,
+    nodeB,
 	}
 
 	cacheList(list)
@@ -48,8 +60,8 @@ func Test_List(t *testing.T) {
 	List(NewContext(""))
 
 	actual := output.String()
-
-	bIndex := strings.Index(actual, "b-node.local")
+	
+  bIndex := strings.Index(actual, "b-node.local")
 	aIndex := strings.Index(actual, "a-node.local")
 
 	if bIndex == -1 || aIndex == -1 {

--- a/src/rv/cache_test.go
+++ b/src/rv/cache_test.go
@@ -10,7 +10,11 @@ import (
 
 func Test_WritesTheNodeList(t *testing.T) {
 	list := NodeList{
-		"my-node.local": "127.0.0.1",
+    Node{
+      id: "abc123",
+      ip: "127.0.0.1",
+      name: "nodeA",
+    },
 	}
 
 	cacheList(list)
@@ -26,8 +30,8 @@ func Test_WritesTheNodeList(t *testing.T) {
 	var unmarshalled NodeList
 	dec.Decode(&unmarshalled)
 
-	if unmarshalled["my-node.local"] != "127.0.0.1" {
-		t.Errorf("Expected 127.0.0.1, but got %s", unmarshalled["my-node.local"])
+	if unmarshalled[0].ip != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, but got %s", unmarshalled[0])
 	}
 
 	os.Remove("/tmp/rv-cache")
@@ -35,14 +39,18 @@ func Test_WritesTheNodeList(t *testing.T) {
 
 func Test_ReadsCacheIfUnderTTL(t *testing.T) {
 	l := NodeList{
-		"my-node.local": "127.0.0.1",
+    Node{
+      id: "abc123",
+      ip: "127.0.0.1",
+      name: "nodeA",
+    },
 	}
 
 	cacheList(l)
 	list := cachedList()
 
-	if list["my-node.local"] != "127.0.0.1" {
-		t.Errorf("Expected 127.0.0.1, but got %s", list["my-node.local"])
+	if list[0].ip != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, but got %s", list[0])
 	}
 
 	os.Remove("/tmp/rv-cache")
@@ -50,7 +58,11 @@ func Test_ReadsCacheIfUnderTTL(t *testing.T) {
 
 func Test_ReturnsNothingIfCacheIsExpired(t *testing.T) {
 	l := NodeList{
-		"my-node.local": "127.0.0.1",
+    Node{
+      id: "abc123",
+      ip: "127.0.0.1",
+      name: "nodeA",
+    },
 	}
 
 	cacheList(l)


### PR DESCRIPTION
This adds the ability to get the instance-id and make sure that the returned nodes are actually unique. I like this approach better than the arbitrary number postfix even though it's downside is that the list is not sorted. Easily fixed with `rv l | sort`. Unix way, amirite? 

```
⮀ bin/rv l
Name                              Instance ID  Private IP Address
prod.elasticsearch                i-44b79fc1   10.0.1.211
stable                            i-e0528ca5   10.0.0.15
prod.worker-feed                  i-93caa625   10.0.1.10
prod.worker-bump                  i-05010ab5   10.0.2.92
```
